### PR TITLE
Add OSV client and cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 
 # virtual env
 .venv
+
+# sample
+sample

--- a/app/dependencies/schema.py
+++ b/app/dependencies/schema.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from pydantic import BaseModel
 
 
@@ -5,3 +6,21 @@ class Dependency(BaseModel):
     name: str
     specs: list[tuple]
     extras: list = []
+
+    def __hash__(self):
+        specs_str = tuple("".join(spec) for spec in self.specs)
+        extras_str = tuple(self.extras)
+        return hash((self.name, specs_str, extras_str))
+
+    def __eq__(self, other):
+        if not isinstance(other, Dependency):
+            return False
+        return self.name == other.name and self.specs == other.specs and self.extras == other.extras
+
+
+class DependencyData(BaseModel):
+    user: str
+    app_name: str
+    dependecy: Dependency
+    vulnerability: list = []
+    last_scanned: datetime

--- a/app/vulnerabilities/client.py
+++ b/app/vulnerabilities/client.py
@@ -1,0 +1,82 @@
+import asyncio
+import httpx
+from app.dependencies.schema import Dependency
+from app.vulnerabilities.memory_cache import InMemoryTTLCache
+from app.vulnerabilities.schema import Vulnerability
+
+
+class OSVClient:
+    def __init__(
+        self,
+        base_url: str = "https://api.osv.dev/v1/query",
+        cache: InMemoryTTLCache = None,
+        max_retries: int = 3,
+        backoff_factor: float = 0.5,
+    ):
+        self.base_url = base_url
+        self.cache = cache or InMemoryTTLCache(ttl_seconds=900)
+        self.max_retries = max_retries
+        self.backoff_factor = backoff_factor
+
+    async def fetch_vulnerabilities(self, dependency: Dependency) -> list[Vulnerability]:
+        cached = self.cache.get(dependency)
+        if cached is not None:
+            return cached
+
+        payload = {
+            "package": {"name": dependency.name, "ecosystem": "PyPI"},
+            "version": dependency.specs[0][1],
+        }
+
+        data = await self._call_with_retry_and_backoff(
+            payload, self.max_retries, self.backoff_factor
+        )
+        vulnerabilities = []
+
+        for vuln_data in data.get("vulns", []):
+            vulnerabilities.append(
+                Vulnerability(
+                    id=vuln_data.get("id"),
+                    summary=vuln_data.get("summary", ""),
+                    details=vuln_data.get("details", ""),
+                    aliases=vuln_data.get("aliases", []),
+                    references=vuln_data.get("references", []),
+                    severity=vuln_data.get("database_specific", {}).get("severity", ""),
+                    severity_details=vuln_data.get("severity", []),
+                )
+            )
+
+        self.cache.set(dependency, vulnerabilities)
+
+        asyncio.create_task(self.update_affected_version(dependency, data, vulnerabilities))
+
+        return vulnerabilities
+
+    async def update_affected_version(self, dependency, data, vulnerabilities):
+        for vuln_data in data.get("vulns", []):
+            for affected in vuln_data.get("affected", []):
+                for version in affected.get("versions", []):
+                    dep = Dependency(name=dependency.name, specs=[("==", version)])
+                    if self.cache.get(dep) is None:
+                        self.cache.set(dep, vulnerabilities)
+
+    async def _call_with_retry_and_backoff(self, payload, max_retries, backoff_factor):
+        for attempt in range(max_retries):
+            try:
+                async with httpx.AsyncClient(timeout=10) as client:
+                    response = await client.post(self.base_url, json=payload)
+                    response.raise_for_status()
+
+                    data = response.json()
+
+                    return data
+
+            except (httpx.HTTPError, httpx.TimeoutException) as e:
+                if attempt < max_retries - 1:
+                    sleep_time = backoff_factor * (2**attempt)
+                    await asyncio.sleep(sleep_time)
+                    continue
+                else:
+                    raise RuntimeError(
+                        f"Failed to fetch vulnerabilities after {max_retries} attempts: {e}"
+                    ) from e

--- a/app/vulnerabilities/memory_cache.py
+++ b/app/vulnerabilities/memory_cache.py
@@ -1,0 +1,28 @@
+from datetime import datetime, timedelta, UTC
+from app.dependencies.schema import Dependency
+
+
+class InMemoryTTLCache:
+    def __init__(self, ttl_seconds: int = 900):
+        self.ttl_seconds = ttl_seconds
+        self.store: dict[Dependency, dict] = {}
+
+    def set(self, key: Dependency, value: dict):
+        expiry_time = datetime.now(tz=UTC) + timedelta(seconds=self.ttl_seconds)
+        self.store[key] = (value, expiry_time)
+
+    def get(self, key: Dependency) -> dict:
+        if key not in self.store:
+            return None
+        value, expiry_time = self.store[key]
+        if datetime.now(tz=UTC) > expiry_time:
+            del self.store[key]
+            return None
+        return value
+
+    def delete(self, key: Dependency):
+        if key in self.store:
+            del self.store[key]
+
+    def clear(self):
+        self.store.clear()

--- a/app/vulnerabilities/schema.py
+++ b/app/vulnerabilities/schema.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class Vulnerability(BaseModel):
+    id: str
+    summary: str
+    details: str
+    aliases: list[str]
+    references: list[dict]
+    severity: str
+    severity_details: list[dict]

--- a/collect_sample.sh
+++ b/collect_sample.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+mkdir -p sample
+
+declare -A packages
+packages=(
+  ["fastapi"]="0.95.1"
+  ["flask"]="2.0.1"
+  ["requests"]="2.25.1"
+  ["django"]="3.2.7"
+  ["numpy"]="1.19.5"
+)
+
+for package in "${!packages[@]}"
+do
+  version=${packages[$package]}
+  echo "Fetching vulnerabilities for $package==$version ..."
+
+  curl -s -X POST https://api.osv.dev/v1/query \
+    -H "Content-Type: application/json" \
+    -d "{\"package\":{\"name\":\"$package\",\"ecosystem\":\"PyPI\"},\"version\":\"$version\"}" \
+    -o "sample/${package}_${version}.json"
+done
+
+echo "Done. Results saved in ./sample/"

--- a/tests/dependencies/test_dependecies_schema.py
+++ b/tests/dependencies/test_dependecies_schema.py
@@ -1,0 +1,22 @@
+from app.dependencies.schema import Dependency
+
+
+def test_dependency_hash_and_equality():
+    dep1 = Dependency(name="fastapi", specs=[("==", "0.95.1")], extras=["uvicorn"])
+    dep2 = Dependency(name="fastapi", specs=[("==", "0.95.1")], extras=["uvicorn"])
+    dep3 = Dependency(name="fastapi", specs=[(">=", "0.99.0")], extras=["uvicorn"])
+
+    assert dep1 == dep2
+    assert dep1 != dep3
+
+
+def test_dependency_can_be_used_as_dict_key():
+    dep1 = Dependency(name="fastapi", specs=[("==", "0.95.1")], extras=["uvicorn"])
+    dep2 = Dependency(name="fastapi", specs=[("==", "0.95.1")], extras=["uvicorn"])
+    dep3 = Dependency(name="requests", specs=[("==", "2.25.1")])
+
+    dep_dict = {dep1: "used successfully"}
+
+    assert dep2 in dep_dict
+    assert dep_dict[dep2] == "used successfully"
+    assert dep3 not in dep_dict

--- a/tests/vulnerabilities/integration/test_vulnerability_client.py
+++ b/tests/vulnerabilities/integration/test_vulnerability_client.py
@@ -1,0 +1,26 @@
+import pytest
+from app.dependencies.schema import Dependency
+from app.vulnerabilities.client import OSVClient
+from app.vulnerabilities.schema import Vulnerability
+
+
+@pytest.mark.asyncio
+async def test_osv_client_real_api_query():
+    client = OSVClient()
+
+    dep = Dependency(name="flask", specs=[("==", "2.0.1")])
+
+    vulnerabilities = await client.fetch_vulnerabilities(dep)
+
+    assert isinstance(vulnerabilities, list)
+
+    if vulnerabilities:
+        assert isinstance(vulnerabilities[0], Vulnerability)
+        assert vulnerabilities[0].id
+        assert isinstance(vulnerabilities[0].aliases, list)
+        assert isinstance(vulnerabilities[0].references, list)
+
+    cached = client.cache.get(dep)
+    assert cached is not None
+    assert isinstance(cached, list)
+    assert all(isinstance(v, Vulnerability) for v in cached)

--- a/tests/vulnerabilities/test_vulnerabilities_client.py
+++ b/tests/vulnerabilities/test_vulnerabilities_client.py
@@ -1,0 +1,97 @@
+import asyncio
+from httpx import TimeoutException
+import pytest
+import pytest_asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+from app.dependencies.schema import Dependency
+from app.vulnerabilities.client import OSVClient
+from app.vulnerabilities.schema import Vulnerability
+
+
+@pytest_asyncio.fixture
+async def osv_client():
+    return OSVClient(max_retries=3, backoff_factor=0)
+
+
+@pytest.mark.asyncio
+async def test_fetch_vulnerabilities_success(osv_client):
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+
+    dummy_response = {
+        "vulns": [
+            {
+                "id": "GHSA-xxxx-yyyy-zzzz",
+                "summary": "Test Vulnerability",
+                "details": "Details here",
+                "aliases": ["CVE-2023-12345"],
+                "references": [{"type": "ADVISORY", "url": "https://example.com"}],
+                "affected": [{"versions": ["0.95.1", "0.91.0"]}],
+                "severity": [
+                    {"type": "CVSS_V3", "score": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:N"}
+                ],
+                "database_specific": {"severity": "MEDIUM"},
+            }
+        ]
+    }
+
+    with patch(
+        "app.vulnerabilities.client.httpx.AsyncClient.post", new_callable=AsyncMock
+    ) as mock_post:
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = dummy_response
+
+        mock_post.return_value = mock_response
+
+        vulnerabilities = await osv_client.fetch_vulnerabilities(dep)
+
+        assert len(vulnerabilities) == 1
+        assert isinstance(vulnerabilities[0], Vulnerability)
+        assert vulnerabilities[0].id == "GHSA-xxxx-yyyy-zzzz"
+
+        await asyncio.sleep(0.1)
+        dep_affected = Dependency(name="fastapi", specs=[("==", "0.91.0")])
+
+        cached = osv_client.cache.get(dep_affected)
+        assert cached is not None
+        assert cached[0].id == "GHSA-xxxx-yyyy-zzzz"
+
+
+@pytest.mark.asyncio
+async def test_fetch_vulnerabilities_cached(osv_client):
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+
+    vuln = Vulnerability(
+        id="GHSA-cached",
+        summary="Cached vuln",
+        details="Cached details",
+        aliases=[],
+        references=[],
+        severity="MEDIUM",
+        severity_details=[
+            {"type": "CVSS_V3", "score": "CVSS:3.1/AV:L/AC:H/PR:H/UI:R/S:U/C:H/I:H/A:N"}
+        ],
+    )
+
+    osv_client.cache.set(dep, [vuln])
+
+    vulnerabilities = await osv_client.fetch_vulnerabilities(dep)
+
+    assert len(vulnerabilities) == 1
+    assert vulnerabilities[0].id == "GHSA-cached"
+
+
+@pytest.mark.asyncio
+async def test_fetch_vulnerabilities_retries_and_fails(osv_client):
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+
+    with patch(
+        "app.vulnerabilities.client.httpx.AsyncClient.post", new_callable=AsyncMock
+    ) as mock_post:
+        mock_post.side_effect = TimeoutException("Timeout simulated")
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await osv_client.fetch_vulnerabilities(dep)
+
+        assert "Failed to fetch vulnerabilities" in str(exc_info.value)
+        assert mock_post.call_count == osv_client.max_retries

--- a/tests/vulnerabilities/test_vulnerabilities_memory_cache.py
+++ b/tests/vulnerabilities/test_vulnerabilities_memory_cache.py
@@ -1,0 +1,55 @@
+import asyncio
+import pytest
+from app.vulnerabilities.memory_cache import InMemoryTTLCache
+from app.dependencies.schema import Dependency
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_successful():
+    cache = InMemoryTTLCache(ttl_seconds=10)
+
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+
+    cache.set(dep, {"vulnerabilities": ["CVE-2023-12345"]})
+
+    assert cache.get(dep) == {"vulnerabilities": ["CVE-2023-12345"]}
+
+
+@pytest.mark.asyncio
+async def test_cache_entry_expires_after_ttl():
+    cache = InMemoryTTLCache(ttl_seconds=1)
+
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+
+    cache.set(dep, {"vulnerabilities": ["CVE-2023-12345"]})
+    await asyncio.sleep(1.5)
+
+    assert cache.get(dep) is None
+
+
+@pytest.mark.asyncio
+async def test_cache_delete_key():
+    cache = InMemoryTTLCache(ttl_seconds=10)
+
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+
+    cache.set(dep, {"vulnerabilities": ["CVE-2023-12345"]})
+    cache.delete(dep)
+
+    assert cache.get(dep) is None
+
+
+@pytest.mark.asyncio
+async def test_cache_clear_all_entries():
+    cache = InMemoryTTLCache(ttl_seconds=10)
+
+    dep1 = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+    dep2 = Dependency(name="requests", specs=[(">=", "2.25.1")])
+
+    cache.set(dep1, {"vulnerabilities": ["CVE-2023-12345"]})
+    cache.set(dep2, {"vulnerabilities": ["CVE-2023-67890"]})
+
+    cache.clear()
+
+    assert cache.get(dep1) is None
+    assert cache.get(dep2) is None


### PR DESCRIPTION
- add a basic bash script to store data in sample, and add that to .gitignore
- add dependency cache that stores dependency as key and vulnerabilities as the values
- I went beyond basic caching by parsing the affected versions section and adding them to the cache through an async task
- tests are getting a bit on the lighter side, because I am running out of time and there are core components still pending

