### PR TITLE
ENH: add api for fetching dependencies by applications

### DIFF
--- a/app/applications/routes.py
+++ b/app/applications/routes.py
@@ -3,6 +3,8 @@ import requirements
 from fastapi import APIRouter, BackgroundTasks, Depends, File, Form, HTTPException, UploadFile
 
 from app.applications.schema import Application
+from app.dependencies.routes import get_dependency_memory
+from app.dependencies.schema import DependencyData
 from app.tasks.scan_dependencies import scan_dependencies_for_application
 from app.fake_auth import get_current_user
 from app.applications.memory import ApplicationMemory
@@ -47,6 +49,16 @@ async def fetch_all_applications(
         return APPLICATION_MEMORY.get_by_user(user)
     except KeyError as e:
         raise HTTPException(status_code=404, detail="User not found") from e
+
+
+@application_routes.get("/applications/{app_name}/dependencies")
+async def fetch_application_dependencies(
+    app_name: str, user: Annotated[str, Depends(get_current_user)]
+) -> list[DependencyData]:
+    data = get_dependency_memory().get_by_user_and_app(user=user, app_name=app_name)
+    if len(data) == 0:
+        raise HTTPException(status_code=404, detail="Dependencies for application not found")
+    return data
 
 
 def get_application_memory():

--- a/tests/applications/test_applications_routes.py
+++ b/tests/applications/test_applications_routes.py
@@ -1,10 +1,14 @@
+from datetime import datetime
 import pytest_asyncio
 import pytest
 from httpx import ASGITransport, AsyncClient
 from fastapi import FastAPI
 from app.applications.routes import application_routes, get_application_memory
 from app.applications.schema import Application
+from app.dependencies.routes import get_dependency_memory
+from app.dependencies.schema import Dependency
 from app.fake_auth import get_current_user
+from app.vulnerabilities.schema import Vulnerability
 
 
 @pytest_asyncio.fixture
@@ -115,3 +119,46 @@ async def test_fetch_applications_for_existing_user(client):
     assert data[0]["name"] == app1.name
     assert data[0]["description"] == app1.description
     assert data[0]["user"] == app1.user
+
+
+@pytest.mark.asyncio
+async def test_fetch_application_dependencies_success(client):
+    dep = Dependency(name="fastapi", specs=[("==", "0.95.1")])
+    vuln = Vulnerability(
+        id="GHSA-xxxx-yyyy-zzzz",
+        summary="Test Vulnerability",
+        details="Details",
+        aliases=["CVE-2023-12345"],
+        references=[],
+        severity="",
+        severity_details=[],
+    )
+
+    get_dependency_memory().insert(
+        user="fake_user",
+        app_name="test_app",
+        dependency=dep,
+        vulns=[vuln],
+        last_scanned=datetime.now(),
+    )
+    response = await client.get("/applications/test_app/dependencies")
+
+    assert response.status_code == 200
+    assert len(response.json()) == 1
+    data = response.json()[0]
+
+    assert data["user"] == "fake_user"
+    assert data["app_name"] == "test_app"
+    assert data["dependency"] == {"name": "fastapi", "specs": [["==", "0.95.1"]], "extras": []}
+    assert len(data["vulnerability"]) == 1
+    assert data["vulnerability"][0]["id"] == "GHSA-xxxx-yyyy-zzzz"
+
+
+@pytest.mark.asyncio
+async def test_fetch_application_dependencies_not_found(client):
+    get_dependency_memory().dependencies.clear()
+
+    response = await client.get("/applications/test_app/dependencies")
+
+    assert response.status_code == 404
+    assert response.json()["detail"] == "Dependencies for application not found"


### PR DESCRIPTION
- add `GET /application/app_name/dependencies` to fetch dependencies from the main table

**Note**: Due to the time constraint, everything is coming from that one dataset now 